### PR TITLE
feat: Configure Next.js app for static export to GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main # Or your default/production branch
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    concurrency: # Allow only one deployment at a time for this workflow
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM 📦
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8 # Specify your pnpm version if different
+          # No run_install: true here, will do it manually after Node setup
+
+      - name: Setup Node.js ⚙️
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18' # Specify your Node.js version
+          cache: 'pnpm' # Enable caching for pnpm
+
+      - name: Install Dependencies 👨‍💻
+        run: pnpm install --frozen-lockfile
+
+      - name: Build 🏗️
+        env:
+          # If you have a GITHUB_TOKEN for accessing private repositories during build
+          # GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Example for configuring the default repo at build time (requires code changes to read these)
+          # NEXT_PUBLIC_GITHUB_REPO_OWNER: 'dendronhq'
+          # NEXT_PUBLIC_GITHUB_REPO_NAME: 'dendron-site'
+        run: pnpm run build # This script should be 'next build && next export'
+
+      - name: Deploy 🚀
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+          # user_name: 'github-actions[bot]' # Optional: Custom commit user
+          # user_email: 'github-actions[bot]@users.noreply.github.com' # Optional: Custom commit email
+          # commit_message: 'Deploy to GitHub Pages' # Optional: Custom commit message
+          # cname: your.custom.domain.com # Optional: If you use a custom domain

--- a/app/wiki/page.tsx
+++ b/app/wiki/page.tsx
@@ -30,12 +30,14 @@ export default function WikiPage() {
       try {
         // Get repository info from localStorage
         const storedRepo = localStorage.getItem("dendron-repo")
-        if (!storedRepo) {
-          router.push("/")
-          return
+        let repo: RepoInfo;
+        if (typeof window === 'undefined' || !storedRepo) {
+          // Build-time or no stored repo, use a default for static generation
+          console.log("Using default repository for static build or no stored repo.");
+          repo = { owner: "dendronhq", repo: "dendron-site", source: "github", url: "https://github.com/dendronhq/dendron-site" };
+        } else {
+          repo = JSON.parse(storedRepo);
         }
-
-        const repo: RepoInfo = JSON.parse(storedRepo)
         setRepoInfo(repo)
 
         // Determine source and load files accordingly

--- a/app/wiki/services/CacheService.ts
+++ b/app/wiki/services/CacheService.ts
@@ -14,8 +14,17 @@ export class CacheService {
   private dbName = "dendron-wiki-cache"
   private dbVersion = 1
   private db: IDBDatabase | null = null
+  private isBrowser: boolean;
+
+  constructor() {
+    this.isBrowser = typeof window !== 'undefined' && typeof window.indexedDB !== 'undefined';
+  }
 
   async init(): Promise<void> {
+    if (!this.isBrowser) {
+      console.log("CacheService: Not in a browser environment, IndexedDB operations disabled.");
+      return Promise.resolve();
+    }
     return new Promise((resolve, reject) => {
       const request = indexedDB.open(this.dbName, this.dbVersion)
 
@@ -49,6 +58,9 @@ export class CacheService {
   }
 
   async cacheFiles(files: any[], metadata: CacheMetadata): Promise<void> {
+    if (!this.isBrowser) {
+      return Promise.resolve();
+    }
     if (!this.db) {
       await this.init()
     }
@@ -87,6 +99,9 @@ export class CacheService {
   }
 
   async cacheNotes(notes: any[]): Promise<void> {
+    if (!this.isBrowser) {
+      return Promise.resolve();
+    }
     if (!this.db) {
       await this.init()
     }
@@ -119,6 +134,9 @@ export class CacheService {
 
   // Fix the getFiles method to properly retrieve files from cache
   async getFiles(source: "github" | "local", owner?: string, repo?: string): Promise<any[] | null> {
+    if (!this.isBrowser) {
+      return Promise.resolve(null);
+    }
     if (!this.db) {
       await this.init()
     }
@@ -187,6 +205,9 @@ export class CacheService {
   }
 
   async getNotes(): Promise<any[] | null> {
+    if (!this.isBrowser) {
+      return Promise.resolve(null);
+    }
     if (!this.db) {
       await this.init()
     }
@@ -214,6 +235,9 @@ export class CacheService {
   }
 
   async getCacheMetadata(source: "github" | "local", owner?: string, repo?: string): Promise<CacheMetadata | null> {
+    if (!this.isBrowser) {
+      return Promise.resolve(null);
+    }
     if (!this.db) {
       await this.init()
     }
@@ -242,6 +266,9 @@ export class CacheService {
   }
 
   async clearCache(): Promise<void> {
+    if (!this.isBrowser) {
+      return Promise.resolve();
+    }
     if (!this.db) {
       await this.init()
     }

--- a/app/wiki/services/GitHubService.ts
+++ b/app/wiki/services/GitHubService.ts
@@ -497,9 +497,17 @@ export class GitHubService {
 
   private getGitHubToken(): string | null {
     try {
-      return localStorage.getItem("github-token")
+      // Prefer environment variable at build time or if available
+      if (typeof process !== 'undefined' && process.env && process.env.GITHUB_TOKEN) {
+        return process.env.GITHUB_TOKEN;
+      }
+      // Fallback to localStorage for client-side use
+      if (typeof localStorage !== 'undefined') {
+        return localStorage.getItem("github-token");
+      }
+      return null;
     } catch {
-      return null
+      return null;
     }
   }
 

--- a/app/wiki/services/LocalFileService.ts
+++ b/app/wiki/services/LocalFileService.ts
@@ -25,6 +25,21 @@ export class LocalFileService {
       { id: "process-files", name: "Processing markdown files", status: "pending" },
     ]
 
+    if (typeof window === 'undefined' || typeof window.showDirectoryPicker === 'undefined') {
+      console.log("LocalFileService: Not in a browser environment or File System Access API not supported. Returning demo files.");
+      // Update tasks to reflect this path
+      if (onProgress) {
+         tasks[0].status = "completed"; // Or "error" if preferred
+         tasks[0].message = "File System Access API not supported, using demo content.";
+         tasks[1].status = "completed";
+         tasks[1].message = "File reading skipped for demo.";
+         tasks[2].status = "completed";
+         tasks[2].message = "Demo content created.";
+         onProgress(tasks.map(task => ({...task, status: "completed"}))); // Mark all as completed or skipped
+      }
+      return Promise.resolve(this.createDemoFiles());
+    }
+
     const updateProgress = () => {
       onProgress?.(tasks)
     }


### PR DESCRIPTION
I've refactored the application to enable static site generation compatible with GitHub Pages.

Key changes include:
- Modified `package.json` build script to align with `output: 'export'` in `next.config.mjs`.
- Updated `app/wiki/page.tsx` to use a default GitHub repository for build-time data fetching, removing reliance on localStorage for initial content.
- Modified `GitHubService` to allow GitHub token provision via environment variables for build processes and disabled browser-specific cache services (`CacheService`, `LocalFileService`) during build to prevent errors.
- Ensured `DendronParser` correctly falls back to main-thread processing when certain browser features are unavailable during build.
- Added a GitHub Actions workflow (`.github/workflows/deploy.yml`) to automate the build and deployment of the static site to the `gh-pages` branch.

The application now builds into the `out/` directory, ready for static hosting. Mermaid diagrams will continue to render client-side.